### PR TITLE
Fix plugin not working with Sonarqube > 9.0.

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugins/icode/model/RulesDefinition.java
+++ b/src/main/java/fr/cnes/sonar/plugins/icode/model/RulesDefinition.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * It contains meta data about rules definition.
  */
-@XStreamAlias("icodelint-rules")
+@XStreamAlias("rules")
 @XStreamImplicitCollection("icodeRules")
 @XStreamInclude(Rule.class)
 public class RulesDefinition {

--- a/src/main/resources/rules/icode-f77-rules.xml
+++ b/src/main/resources/rules/icode-f77-rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<icodelint-rules>
+<rules>
 	<rule>
 		<key>Parsing Error</key>
 		<name>Parsing Error</name>
@@ -714,4 +714,4 @@ Please, report this error to i-Code CNES maintainers to improve the tool: <a hre
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>30min</remediationFunctionBaseEffort>
 	</rule>
-</icodelint-rules>
+</rules>

--- a/src/main/resources/rules/icode-f90-rules.xml
+++ b/src/main/resources/rules/icode-f90-rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<icodelint-rules>
+<rules>
 	<rule>
 		<key>Parsing Error</key>
 		<name>Parsing Error</name>
@@ -802,4 +802,4 @@ Please, report this error to i-Code CNES maintainers to improve the tool: <a hre
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>30min</remediationFunctionBaseEffort>
 	</rule>
-</icodelint-rules>
+</rules>


### PR DESCRIPTION
## Proposed changes

> _Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

This pull request includes changes proposed to fix bug #81 Plugin no longer works with Sonarqube > 9.0

## Types of changes

What types of changes does your code introduce to this plugin?
> _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

> _List here all issues closed by your changes. Use a list of items like `- [x] Close #0`_

- [x] Close #81 

## Checklist

> _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/lequal/sonar-icode-cnes-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/lequal/sonar-icode-cnes-plugin/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and GitHub CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

> If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Since version 9.0.0 of SonarQube, the implementation of RulesDefinitionXmlLoader (on which sonar-icode-cnes-plugin relies to load the rules), require the XML ruleset to have <rules> as the root tag. This was not required in previous implementation of RulesDefinitionXmlLoader.

![RulesDefinitionXmlLoader](https://github.com/cnescatlab/sonar-icode-cnes-plugin/assets/20472238/e4fe818f-fdd8-4937-834c-1d84f0e83790)

The rules XML files in sonar-icode-cnes-plugin (icode-f77-rules.xml and icode-f90-rules.xml) have <icodelint-rules> as the root tag, this change in RulesDefinitionXmlLoader in Sonar 9.0.0 makes the process of loading iCode rules to break during SonarQube startup, due to SonarQube not being able to find the rules, as they are not under the expected <rules> tag.

![icode-f77-rules](https://github.com/cnescatlab/sonar-icode-cnes-plugin/assets/20472238/d17d1290-8b4c-4817-b8fb-ab9ddb8e0e3b)

Changing the root tag in icode-f77-rules.xml and icode-f90-rules.xml to <rules> (and the annotation in fr.cnes.sonar.plugins.icode.model.RulesDefinition to also do the processing with this tag) fixes the issue, and SonarQube in versions >= 9 starts and loads sonar-icode-cnes-plugin correctly. 

![new-rules-xml](https://github.com/cnescatlab/sonar-icode-cnes-plugin/assets/20472238/67d71fa7-00fc-49f6-8d7b-7ae13c79f87e)

![RulesDefinition](https://github.com/cnescatlab/sonar-icode-cnes-plugin/assets/20472238/b34f202e-c1fa-4ebb-85af-fdab66879a65)

This fix does not break backwards compatibility, working in SonarQube versions <9. 
Tests have been carried out with SonarQube versions 8.4, 8.9, 9.7, 9.9 (LTS) and 10.0, working correctly in all of them.
